### PR TITLE
Make StarlightBlog work with StarlightImageZoom

### DIFF
--- a/website/astro.config.mjs
+++ b/website/astro.config.mjs
@@ -1,6 +1,7 @@
 import { defineConfig } from 'astro/config';
 import starlight from '@astrojs/starlight';
 import starlightBlog from 'starlight-blog';
+import starlightImageZoom from "starlight-image-zoom";
 import starlightHeadingBadges from 'starlight-heading-badges';
 
 // https://astro.build/config
@@ -29,11 +30,15 @@ export default defineConfig({
 				},
 			],
 			plugins: [
+				starlightImageZoom(),
 				starlightBlog({
 				  title: 'Devlog',
 				}),
 				starlightHeadingBadges()
 			],
+		        components: {
+				MarkdownContent: "./src/components/MarkdownContent.astro",
+		        },
 		}),
 	],
 });

--- a/website/src/components/MarkdownContent.astro
+++ b/website/src/components/MarkdownContent.astro
@@ -1,0 +1,8 @@
+---
+import type { Props } from '@astrojs/starlight/props'
+import Default from "starlight-blog/overrides/MarkdownContent.astro"
+import ImageZoom from 'starlight-image-zoom/components/ImageZoom.astro'
+---
+
+<ImageZoom />
+<Default {...Astro.props}><slot /></Default>


### PR DESCRIPTION
Hello!

I see that your `package.json` includes the Starlight Image Zoom plugin but it isn't used in the application.

I have created this PR, so that the Starlight Blog works with the Image Zoom plugin because this requires a custom component override.

I hope this helps!

Have a nice day, bye!